### PR TITLE
[REF] Labels <0 are set to 0

### DIFF
--- a/brainnotation/images.py
+++ b/brainnotation/images.py
@@ -453,7 +453,7 @@ def relabel_gifti(parcellation, background=None, offset=None):
                 labels = [f for f in labels if f.key != idx]
 
         # reset labels so they're consecutive and update label keys
-        data = _relabel(data, minval=minval, bgval=0)
+        data = _relabel(np.clip(data, 0, None), minval=minval, bgval=0)
         ids = np.unique(data)
         new_labels = []
         if len(labels) > 0:


### PR DESCRIPTION
This will only impact usage of `images.annot_to_gifti()` and `images.relabel_gifti()`, wherein users providing annotation and/or gifti files that have negative labels will find those labels are automatically set to the background value (0). Because, honestly, who uses negative labels? :monocle_face: 

Will try and create tests for the impacted functions (since none exist right now!).